### PR TITLE
Add missing setInvalidTypeConstraint()

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1057,6 +1057,7 @@ bool Sema::ActOnTypeConstraint(TemplateIdAnnotation *TypeConstr,
          diag::err_type_constraint_missing_arguments) << CD <<
          FixItHint::CreateInsertion(ConstrainedParameter->getLocation(),
                                     "<...>");
+    ConstrainedParameter->setInvalidTypeConstraint();
     return true;
   }
 


### PR DESCRIPTION
Add missing setInvalidTypeConstraint() after detecting missing template arguments.

Fixes a crash down the line where the uninitialized type-constraint was accessed.