### PR TITLE
Fix crash in cxx2a-constrained-template-param test.

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1046,6 +1046,7 @@ bool Sema::ActOnTypeConstraint(TemplateIdAnnotation *TypeConstr,
   if (!CD->isTypeConcept()) {
     Diag(TypeConstr->TemplateNameLoc,
          diag::err_type_constraint_non_type_concept);
+    ConstrainedParameter->setInvalidTypeConstraint();
     return true;
   }
 


### PR DESCRIPTION
Add missing setInvalidTypeConstraint().