### PR TITLE
Fix crash when a lambda contains a constrained parameter pack.

### DIFF
--- a/clang/test/CXX/concepts-ts/expr/expr.prim/expr.prim.lambda/abbrev-syntax.cpp
+++ b/clang/test/CXX/concepts-ts/expr/expr.prim/expr.prim.lambda/abbrev-syntax.cpp
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -std=c++2a -fconcepts-ts -x c++ -verify %s
+
+template<typename>
+concept One = true;
+// expected-note@-1 {{template is declared here}}
+
+template<typename, typename>
+concept Two = true;
+// expected-note@-1 3{{template is declared here}}
+
+auto acc_1 = [](One auto) { return 0; };
+auto rej_1 = [](One<int> auto) { return 0; };
+// expected-error@-1 {{too many template arguments for concept}}
+auto rej_2_1 = [](Two auto) { return 0; };
+// expected-error@-1 {{too few template arguments for concept}}
+auto acc_2_1 = [](Two<int> auto) { return 0; };
+auto rej_2_2 = [](Two<int, int> auto) { return 0; };
+// expected-error@-1 {{too many template arguments for concept}}
+auto rej_2_3 = [](Two<int, int, int> auto) { return 0; };
+// expected-error@-1 {{too many template arguments for concept}}
+
+template<typename T, unsigned Size>
+concept LargerThan = sizeof(T) > Size;
+// expected-note@-1 3{{because 'sizeof(char) > 1U' (1 > 1) evaluated to false}}
+
+template<typename T>
+concept Large = LargerThan<T, 1>;
+// expected-note@-1 3{{because 'LargerThan<char, 1>' evaluated to false}}
+
+auto l1 = [](Large auto l) { return l; };
+// expected-note@-1{{candidate template ignored: constraints not satisfied [with l:auto = char]}}
+// expected-note@-2{{because 'char' does not satisfy 'Large'}}
+auto l1t1 = l1('a');
+// expected-error@-1{{no matching function for call to object of type '(lambda at}}
+auto l1t2 = l1(1);
+
+auto l2 = [](Large auto ...ls) { return 0; };
+// expected-note@-1{{candidate template ignored: constraints not satisfied [with ls:auto = <char>]}}
+// expected-note@-2{{candidate template ignored: constraints not satisfied [with ls:auto = <int, char>]}}
+// expected-note@-3 2{{because 'char' does not satisfy 'Large'}}
+auto l2t1 = l2('a');
+// expected-error@-1{{no matching function for call to object of type '(lambda at}}
+auto l2t2 = l2(1, 'a');
+// expected-error@-1{{no matching function for call to object of type '(lambda at}}
+auto l2t3 = l2(1, 2);
+


### PR DESCRIPTION
1) This fixes a crash in code like
    ```
    auto l = [](C auto ...cs) { };
    ```
    see https://godbolt.org/z/B8JCTL
2) Adds the correct concept's location in the lambda parameter list to diagnostics.
    ```
    int main() {
      auto fun = [](Foo auto f) {};
      fun('a');
      return 0;
    }
    ```
    with diagnostic output
    ```
    <source>:5:14: note: candidate template ignored: constraints not satisfied [with f:auto = char]
    auto fun = [](Foo auto f) {};
         ^
    note: because 'char' does not satisfy 'Foo'
    ```
    (last line misses a `SourceLocation`) see https://godbolt.org/z/fPjTaE
    With the fix it correctly points to the beginning of `Foo auto f` 

3) Fixes #48 